### PR TITLE
Readability improvements to SortShuffleReader

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleReader.scala
@@ -275,7 +275,7 @@ private[spark] class SortShuffleReader[K, C](
           // Ideal in the sense that we would move on to the next level after this merge and that
           // level would have exactly maxMergeWidth blocks to merge. This can never be negative,
           // because, at this point, we know blocksAwaitingMerge is at least maxMergeWidth.
-          val idealWidth = blocksAwaitingMerge.size() - mergedBlocksHeadroomAfterMerge
+          val idealWidth = remainingToMergeAtLevel - mergedBlocksHeadroomAfterMerge
           val mergeWidth = math.min(idealWidth, maxMergeWidth)
 
           val blocksToMerge = ArrayBuffer[ShuffleBlock]()

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleReader.scala
@@ -17,9 +17,8 @@
 
 package org.apache.spark.shuffle.sort
 
-import java.io.{BufferedOutputStream, FileOutputStream, File}
+import java.io.{BufferedOutputStream, FileOutputStream}
 import java.util.Comparator
-import java.util.concurrent.{CountDownLatch, TimeUnit, LinkedBlockingQueue}
 
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 
@@ -30,22 +29,19 @@ import org.apache.spark.shuffle.{ShuffleReader, BaseShuffleHandle}
 import org.apache.spark.shuffle.hash.BlockStoreShuffleFetcher
 import org.apache.spark.storage._
 import org.apache.spark.util.CompletionIterator
-import org.apache.spark.util.collection.ExternalSorter
+import org.apache.spark.util.collection.{MergeUtil, TieredDiskMerger}
 
 /**
- * SortShuffleReader assumes that the records within each block are sorted by key, and essentially
- * performs a huge tiered merge between all the map output blocks for a partition.
+ * SortShuffleReader merges and aggregates shuffle data that has already been sorted within each
+ * map output block.
  *
- * As blocks are fetched, stores them on disk or in memory depending on their size. A single
- * background thread merges these blocks and writes the results to disk.
+ * As blocks are fetched, we store them in memory until we fail to acquire space frm the
+ * ShuffleMemoryManager. When this occurs, we merge the in-memory blocks to disk and go back to
+ * fetching.
  *
- * The shape of the tiered merge is controlled by a single parameter, maxMergeWidth, which limits
- * the number of blocks merged at once. At any point during its operation, we can think of the
- * shuffle reader being at a merge "level". The first level merges the fetched map output blocks,
- * at most maxMergeWidth at a time. If the merged blocks created from the first level merge exceed
- * maxMergeWidth, a second level merges the results of the first, and so on. When at last the total
- * blocks fall beneath maxMergeWidth, the final merge feeds into the iterator that read(...)
- * returns.
+ * TieredDiskMerger is responsible for managing the merged on-disk blocks and for supplying an
+ * iterator with their merged contents. The final iterator that is passed to user code merges this
+ * on-disk iterator with the in-memory blocks that have not yet been spilled.
  */
 private[spark] class SortShuffleReader[K, C](
     handle: BaseShuffleHandle[K, _, C],
@@ -57,24 +53,10 @@ private[spark] class SortShuffleReader[K, C](
   require(endPartition == startPartition + 1,
     "Sort shuffle currently only supports fetching one partition")
 
-  sealed trait ShuffleBlock
-  case class MemoryBlock(blockId: BlockId, blockData: ManagedBuffer) extends ShuffleBlock
-  case class FileBlock(blockId: BlockId, mappedFile: File) extends ShuffleBlock
+  private val fileBufferSize = conf.getInt("spark.shuffle.file.buffer.kb", 32) * 1024
 
-  /**
-   * Blocks awaiting merge at the current level. All fetched blocks go here immediately. After the
-   * first level merge of fetched blocks has completed, more levels of merge may be required in
-   * order to not overwhelm the final merge. In those cases, the already-merged blocks awaiting
-   * further merges will go here as well.
-   */
-  private val blocksAwaitingMerge = new LinkedBlockingQueue[ShuffleBlock]()
-  /** Blocks already merged at the current level. */
-  private val mergedBlocks = new LinkedBlockingQueue[ShuffleBlock]()
-  /** The total number of map output blocks to be fetched. */
-  private var numMapBlocks: Int = 0
-  private val mergeFinished = new CountDownLatch(1)
-  private val mergingThread = new MergingThread()
-  private val threadId = Thread.currentThread().getId
+  case class MemoryBlock(blockId: BlockId, blockData: ManagedBuffer)
+
   private var shuffleRawBlockFetcherItr: ShuffleRawBlockFetcherIterator = _
 
   private val dep = handle.dependency
@@ -83,8 +65,9 @@ private[spark] class SortShuffleReader[K, C](
   private val ser = Serializer.getSerializer(dep.serializer)
   private val shuffleMemoryManager = SparkEnv.get.shuffleMemoryManager
 
-  private val maxMergeWidth = conf.getInt("spark.shuffle.maxMergeWidth", 100)
-  private val fileBufferSize = conf.getInt("spark.shuffle.file.buffer.kb", 32) * 1024
+  private val memoryBlocks = new ArrayBuffer[MemoryBlock]()
+
+  private val tieredMerger = new TieredDiskMerger(conf, dep, context)
 
   private val keyComparator: Comparator[K] = dep.keyOrdering.getOrElse(new Comparator[K] {
     override def compare(a: K, b: K) = {
@@ -105,58 +88,61 @@ private[spark] class SortShuffleReader[K, C](
   }
 
   private def sortShuffleRead(): Iterator[Product2[K, C]] = {
-    mergingThread.setDaemon(true)
-    mergingThread.start()
+    tieredMerger.start()
 
     for ((blockId, blockData) <- fetchRawBlocks()) {
       if (blockData.isEmpty) {
         throw new IllegalStateException(s"block $blockId is empty for unknown reason")
       }
 
+      memoryBlocks += MemoryBlock(blockId, blockData.get)
+
+      // Try to fit block in memory. If this fails, merge in-memory blocks to disk.
       val blockSize = blockData.get.size
-      // Try to fit block in memory. If this fails, spill it to disk.
-      val granted = shuffleMemoryManager.tryToAcquire(blockSize)
+      val granted = shuffleMemoryManager.tryToAcquire(blockData.get.size)
       if (granted < blockSize) {
         shuffleMemoryManager.release(granted)
-        logInfo(s"Granted memory $granted for block less than its size $blockSize, " +
-          s"spilling data to file")
+
+        val itrGroup = memoryBlocksToIterators()
+        val partialMergedIter =
+          MergeUtil.mergeSort(itrGroup, keyComparator, dep.keyOrdering, dep.aggregator)
+
+        // Write merged blocks to disk
         val (tmpBlockId, file) = blockManager.diskBlockManager.createTempBlock()
-        val channel = new FileOutputStream(file).getChannel()
-        val byteBuffer = blockData.get.nioByteBuffer()
-        while (byteBuffer.remaining() > 0) {
-          channel.write(byteBuffer)
+        val fos = new BufferedOutputStream(new FileOutputStream(file), fileBufferSize)
+        blockManager.dataSerializeStream(tmpBlockId, fos, partialMergedIter, ser)
+        tieredMerger.registerOnDiskBlock(tmpBlockId, file)
+
+        for (block <- memoryBlocks) {
+          shuffleMemoryManager.release(block.blockData.size)
         }
-        channel.close()
-        blocksAwaitingMerge.offer(FileBlock(tmpBlockId, file))
-      } else {
-        blocksAwaitingMerge.offer(MemoryBlock(blockId, blockData.get))
+        memoryBlocks.clear()
       }
 
       shuffleRawBlockFetcherItr.currentResult = null
     }
+    tieredMerger.doneRegisteringOnDiskBlocks()
 
-    mergeFinished.await()
-
-    // Merge the final group for combiner to directly feed to the reducer
-    val finalMergedPartArray = mergedBlocks.toArray(new Array[ShuffleBlock](mergedBlocks.size()))
-    val finalItrGroup = blocksToRecordIterators(finalMergedPartArray)
-    val mergedItr = if (dep.aggregator.isDefined) {
-      ExternalSorter.mergeWithAggregation(finalItrGroup, dep.aggregator.get.mergeCombiners,
-        keyComparator, dep.keyOrdering.isDefined)
-    } else {
-      ExternalSorter.mergeSort(finalItrGroup, keyComparator)
-    }
-
-    mergedBlocks.clear()
-
-    // Release the shuffle used memory of this thread
-    shuffleMemoryManager.releaseMemoryForThisThread()
+    // Merge on-disk blocks with in-memory blocks to directly feed to the reducer.
+    val finalItrGroup = memoryBlocksToIterators() ++ Seq(tieredMerger.readMerged())
+    val mergedItr =
+      MergeUtil.mergeSort(finalItrGroup, keyComparator, dep.keyOrdering, dep.aggregator)
 
     // Release the in-memory block and on-disk file when iteration is completed.
     val completionItr = CompletionIterator[Product2[K, C], Iterator[Product2[K, C]]](
-      mergedItr, releaseUnusedShuffleBlock(finalMergedPartArray))
+      mergedItr, () => {
+        memoryBlocks.foreach(block => shuffleMemoryManager.release(block.blockData.size))
+        memoryBlocks.clear()
+      })
 
     new InterruptibleIterator(context, completionItr.map(p => (p._1, p._2)))
+  }
+
+  def memoryBlocksToIterators(): Seq[Iterator[Product2[K, C]]] = {
+    memoryBlocks.map{ case MemoryBlock(id, buf) =>
+      blockManager.dataDeserialize(id, buf.nioByteBuffer(), ser)
+        .asInstanceOf[Iterator[Product2[K, C]]]
+    }
   }
 
   override def stop(): Unit = ???
@@ -171,9 +157,11 @@ private[spark] class SortShuffleReader[K, C](
       case (address, splits) =>
         (address, splits.map(s => (ShuffleBlockId(handle.shuffleId, s._1, startPartition), s._2)))
     }
+    var numMapBlocks = 0
     blocksByAddress.foreach { case (_, blocks) =>
       blocks.foreach { case (_, len) => if (len > 0) numMapBlocks += 1 }
     }
+    val threadId = Thread.currentThread.getId
     logInfo(s"Fetching $numMapBlocks blocks for $threadId")
 
     shuffleRawBlockFetcherItr = new ShuffleRawBlockFetcherIterator(
@@ -189,122 +177,5 @@ private[spark] class SortShuffleReader[K, C](
       () => context.taskMetrics.updateShuffleReadMetrics())
 
     new InterruptibleIterator[(BlockId, Option[ManagedBuffer])](context, completionItr)
-  }
-
-  private def blocksToRecordIterators(shufflePartGroup: Seq[ShuffleBlock])
-      : Seq[Iterator[Product2[K, C]]] = {
-     shufflePartGroup.map { part =>
-      val itr = part match {
-        case MemoryBlock(id, buf) =>
-          // Release memory usage
-          shuffleMemoryManager.release(buf.size, threadId)
-          blockManager.dataDeserialize(id, buf.nioByteBuffer(), ser)
-        case FileBlock(id, file) =>
-          val blockData = blockManager.diskStore.getBytes(id).getOrElse(
-            throw new IllegalStateException(s"cannot get data from block $id"))
-          blockManager.dataDeserialize(id, blockData, ser)
-      }
-      itr.asInstanceOf[Iterator[Product2[K, C]]]
-    }.toSeq
-  }
-
-
-  /**
-   * Release the left in-memory buffer or on-disk file after merged.
-   */
-  private def releaseUnusedShuffleBlock(shufflePartGroup: Array[ShuffleBlock]): Unit = {
-    shufflePartGroup.map { part =>
-      part match {
-        case MemoryBlock(id, buf) => buf.release()
-        case FileBlock(id, file) =>
-          try {
-            file.delete()
-          } catch {
-            // Swallow the exception
-            case e: Throwable => logWarning(s"Unexpected errors when deleting file: ${
-              file.getAbsolutePath}", e)
-          }
-      }
-    }
-  }
-
-  private class MergingThread extends Thread {
-    var remainingToMergeAtLevel: Int = _
-
-    override def run() {
-      remainingToMergeAtLevel = numMapBlocks
-      while (remainingToMergeAtLevel > 0) {
-        mergeLevel()
-        assert(blocksAwaitingMerge.size() == 0)
-        assert(remainingToMergeAtLevel == 0)
-        if (mergedBlocks.size() > maxMergeWidth) {
-          // End of the current merge level, but not yet ready to proceed to the final merge.
-          // Swap the merged group and merging group to proceed to the next merge level,
-          blocksAwaitingMerge.addAll(mergedBlocks)
-          remainingToMergeAtLevel = blocksAwaitingMerge.size()
-          mergedBlocks.clear()
-        }
-      }
-      mergeFinished.countDown()
-    }
-
-    /**
-     * Carry out the current merge level. I.e. move all blocks out of blocksAwaitingMerge, either by
-     * merging them or placing them directly in mergedBlocks.
-     */
-    private def mergeLevel() {
-      while (remainingToMergeAtLevel > 0) {
-        if (remainingToMergeAtLevel < maxMergeWidth) {
-          // If the remaining blocks awaiting merge at this level don't exceed the maxMergeWidth,
-          // pass them all on to the next level.
-          while (remainingToMergeAtLevel > 0) {
-            val part = blocksAwaitingMerge.poll(100, TimeUnit.MILLISECONDS)
-            if (part != null) {
-              mergedBlocks.offer(part)
-              remainingToMergeAtLevel -= 1
-            }
-          }
-        } else {
-          // Because the remaining blocks awaiting merge at this level exceed the maxMergeWidth, a
-          // merge is required.
-
-          // Pick a number of blocks to merge that (1) is <= maxMergeWidth, (2) if possible,
-          // ensures that the number of blocks in the next level be <= maxMergeWidth so that it can
-          // be the final merge, and (3) is as small as possible.
-          val mergedBlocksHeadroomAfterMerge = (maxMergeWidth - mergedBlocks.size() - 1)
-          // Ideal in the sense that we would move on to the next level after this merge and that
-          // level would have exactly maxMergeWidth blocks to merge. This can never be negative,
-          // because, at this point, we know blocksAwaitingMerge is at least maxMergeWidth.
-          val idealWidth = remainingToMergeAtLevel - mergedBlocksHeadroomAfterMerge
-          val mergeWidth = math.min(idealWidth, maxMergeWidth)
-
-          val blocksToMerge = ArrayBuffer[ShuffleBlock]()
-          while (blocksToMerge.size < mergeWidth) {
-            val part = blocksAwaitingMerge.poll(100, TimeUnit.MILLISECONDS)
-            if (part != null) {
-              blocksToMerge += part
-              remainingToMergeAtLevel -= 1
-            }
-          }
-
-          // Merge the blocks
-          val itrGroup = blocksToRecordIterators(blocksToMerge)
-          val partialMergedIter = if (dep.aggregator.isDefined) {
-            ExternalSorter.mergeWithAggregation(itrGroup, dep.aggregator.get.mergeCombiners,
-              keyComparator, dep.keyOrdering.isDefined)
-          } else {
-            ExternalSorter.mergeSort(itrGroup, keyComparator)
-          }
-          // Write merged blocks to disk
-          val (tmpBlockId, file) = blockManager.diskBlockManager.createTempBlock()
-          val fos = new BufferedOutputStream(new FileOutputStream(file), fileBufferSize)
-          blockManager.dataSerializeStream(tmpBlockId, fos, partialMergedIter, ser)
-          logInfo(s"Merged ${blocksToMerge.size} blocks into file ${file.getName}")
-
-          releaseUnusedShuffleBlock(blocksToMerge.toArray)
-          mergedBlocks.add(FileBlock(tmpBlockId, file))
-        }
-      }
-    }
   }
 }

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
@@ -29,6 +29,7 @@ import org.apache.spark._
 import org.apache.spark.serializer.{DeserializationStream, Serializer}
 import org.apache.spark.executor.ShuffleWriteMetrics
 import org.apache.spark.storage.{BlockObjectWriter, BlockId}
+import org.apache.spark.network.ManagedBuffer
 
 /**
  * Sorts and potentially merges a number of key-value pairs of type (K, V) to produce key-combiner
@@ -80,8 +81,6 @@ private[spark] class ExternalSorter[K, V, C](
     partitioner: Option[Partitioner] = None,
     ordering: Option[Ordering[K]] = None,
     serializer: Option[Serializer] = None) extends Logging {
-
-  import ExternalSorter._
 
   private val numPartitions = partitioner.map(_.numPartitions).getOrElse(1)
   private val shouldPartition = numPartitions > 1
@@ -194,6 +193,20 @@ private[spark] class ExternalSorter[K, V, C](
     serializerBatchSizes: Array[Long],
     elementsPerPartition: Array[Long])
   private val spills = new ArrayBuffer[SpilledFile]
+
+  def insertInMemoryBlock(buffer: ManagedBuffer) {
+    // try to acquire memory
+    val granted = shuffleMemoryManager.tryToAcquire(buffer.size)
+    if (granted < buffer.size) {
+      if (!spillingEnabled) {
+        throw new IllegalStateException()
+      }
+      // spill in-memory partitions
+    }
+    // maybe spill
+
+    // spilling should probably tell our background merger thread to try stuff
+  }
 
   def insertAll(records: Iterator[_ <: Product2[K, V]]): Unit = {
     // TODO: stop combining if we find that the reduction factor isn't high
@@ -411,12 +424,12 @@ private[spark] class ExternalSorter[K, V, C](
       val iterators = readers.map(_.readNextPartition()) ++ Seq(inMemIterator)
       if (aggregator.isDefined) {
         // Perform partial aggregation across partitions
-        (p, mergeWithAggregation(
+        (p, MergeUtil.mergeWithAggregation(
           iterators, aggregator.get.mergeCombiners, keyComparator, ordering.isDefined))
       } else if (ordering.isDefined) {
         // No aggregator given, but we have an ordering (e.g. used by reduce tasks in sortByKey);
         // sort the elements without trying to merge them
-        (p, mergeSort(iterators, ordering.get))
+        (p, MergeUtil.mergeSort(iterators, ordering.get))
       } else {
         (p, iterators.iterator.flatten)
       }
@@ -729,120 +742,6 @@ private[spark] class ExternalSorter[K, V, C](
       }
       val elem = data.next()
       (elem._1._2, elem._2)
-    }
-  }
-}
-
-private[spark] object ExternalSorter {
-
-  /**
-   * Merge-sort a sequence of (K, C) iterators using a given a comparator for the keys.
-   */
-  def mergeSort[K, C](iterators: Seq[Iterator[Product2[K, C]]], comparator: Comparator[K])
-      : Iterator[Product2[K, C]] =
-  {
-    val bufferedIters = iterators.filter(_.hasNext).map(_.buffered)
-    type Iter = BufferedIterator[Product2[K, C]]
-    val heap = new mutable.PriorityQueue[Iter]()(new Ordering[Iter] {
-      // Use the reverse of comparator.compare because PriorityQueue dequeues the max
-      override def compare(x: Iter, y: Iter): Int = -comparator.compare(x.head._1, y.head._1)
-    })
-    heap.enqueue(bufferedIters: _*)  // Will contain only the iterators with hasNext = true
-    new Iterator[Product2[K, C]] {
-      override def hasNext: Boolean = !heap.isEmpty
-
-      override def next(): Product2[K, C] = {
-        if (!hasNext) {
-          throw new NoSuchElementException
-        }
-        val firstBuf = heap.dequeue()
-        val firstPair = firstBuf.next()
-        if (firstBuf.hasNext) {
-          heap.enqueue(firstBuf)
-        }
-        firstPair
-      }
-    }
-  }
-
-  /**
-   * Merge a sequence of (K, C) iterators by aggregating values for each key, assuming that each
-   * iterator is sorted by key with a given comparator. If the comparator is not a total ordering
-   * (e.g. when we sort objects by hash code and different keys may compare as equal although
-   * they're not), we still merge them by doing equality tests for all keys that compare as equal.
-   */
-  def mergeWithAggregation[K, C](
-      iterators: Seq[Iterator[Product2[K, C]]],
-      mergeCombiners: (C, C) => C,
-      comparator: Comparator[K],
-      totalOrder: Boolean)
-      : Iterator[Product2[K, C]] =
-  {
-    if (!totalOrder) {
-      // We only have a partial ordering, e.g. comparing the keys by hash code, which means that
-      // multiple distinct keys might be treated as equal by the ordering. To deal with this, we
-      // need to read all keys considered equal by the ordering at once and compare them.
-      new Iterator[Iterator[Product2[K, C]]] {
-        val sorted = mergeSort(iterators, comparator).buffered
-
-        // Buffers reused across elements to decrease memory allocation
-        val keys = new ArrayBuffer[K]
-        val combiners = new ArrayBuffer[C]
-
-        override def hasNext: Boolean = sorted.hasNext
-
-        override def next(): Iterator[Product2[K, C]] = {
-          if (!hasNext) {
-            throw new NoSuchElementException
-          }
-          keys.clear()
-          combiners.clear()
-          val firstPair = sorted.next()
-          keys += firstPair._1
-          combiners += firstPair._2
-          val key = firstPair._1
-          while (sorted.hasNext && comparator.compare(sorted.head._1, key) == 0) {
-            val pair = sorted.next()
-            var i = 0
-            var foundKey = false
-            while (i < keys.size && !foundKey) {
-              if (keys(i) == pair._1) {
-                combiners(i) = mergeCombiners(combiners(i), pair._2)
-                foundKey = true
-              }
-              i += 1
-            }
-            if (!foundKey) {
-              keys += pair._1
-              combiners += pair._2
-            }
-          }
-
-          // Note that we return an iterator of elements since we could've had many keys marked
-          // equal by the partial order; we flatten this below to get a flat iterator of (K, C).
-          keys.iterator.zip(combiners.iterator)
-        }
-      }.flatMap(i => i)
-    } else {
-      // We have a total ordering, so the objects with the same key are sequential.
-      new Iterator[Product2[K, C]] {
-        val sorted = mergeSort(iterators, comparator).buffered
-
-        override def hasNext: Boolean = sorted.hasNext
-
-        override def next(): Product2[K, C] = {
-          if (!hasNext) {
-            throw new NoSuchElementException
-          }
-          val elem = sorted.next()
-          val k = elem._1
-          var c = elem._2
-          while (sorted.hasNext && sorted.head._1 == k) {
-            c = mergeCombiners(c, sorted.head._2)
-          }
-          (k, c)
-        }
-      }
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/util/collection/MergeUtil.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/MergeUtil.scala
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util.collection
+
+import java.util.Comparator
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import org.apache.spark.Aggregator
+
+private[spark] object MergeUtil {
+  def mergeSort[K, C](
+      iterators: Seq[Iterator[Product2[K, C]]],
+      comparator: Comparator[K],
+      keyOrdering: Option[Ordering[K]],
+      aggregator: Option[Aggregator[K, _, C]])
+    : Iterator[Product2[K, C]] = {
+    if (aggregator.isDefined) {
+      mergeWithAggregation(iterators, aggregator.get.mergeCombiners,
+        comparator, keyOrdering.isDefined)
+    } else {
+      mergeSort(iterators, comparator)
+    }
+  }
+
+  /**
+   * Merge-sort a sequence of (K, C) iterators using a given a comparator for the keys.
+   */
+  def mergeSort[K, C](iterators: Seq[Iterator[Product2[K, C]]], comparator: Comparator[K])
+    : Iterator[Product2[K, C]] = {
+    val bufferedIters = iterators.filter(_.hasNext).map(_.buffered)
+    type Iter = BufferedIterator[Product2[K, C]]
+    val heap = new mutable.PriorityQueue[Iter]()(new Ordering[Iter] {
+      // Use the reverse of comparator.compare because PriorityQueue dequeues the max
+      override def compare(x: Iter, y: Iter): Int = -comparator.compare(x.head._1, y.head._1)
+    })
+    heap.enqueue(bufferedIters: _*)  // Will contain only the iterators with hasNext = true
+    new Iterator[Product2[K, C]] {
+      override def hasNext: Boolean = !heap.isEmpty
+
+      override def next(): Product2[K, C] = {
+        if (!hasNext) {
+          throw new NoSuchElementException
+        }
+        val firstBuf = heap.dequeue()
+        val firstPair = firstBuf.next()
+        if (firstBuf.hasNext) {
+          heap.enqueue(firstBuf)
+        }
+        firstPair
+      }
+    }
+  }
+
+  /**
+   * Merge a sequence of (K, C) iterators by aggregating values for each key, assuming that each
+   * iterator is sorted by key with a given comparator. If the comparator is not a total ordering
+   * (e.g. when we sort objects by hash code and different keys may compare as equal although
+   * they're not), we still merge them by doing equality tests for all keys that compare as equal.
+   */
+  def mergeWithAggregation[K, C](
+      iterators: Seq[Iterator[Product2[K, C]]],
+      mergeCombiners: (C, C) => C,
+      comparator: Comparator[K],
+      totalOrder: Boolean)
+    : Iterator[Product2[K, C]] = {
+    if (!totalOrder) {
+      // We only have a partial ordering, e.g. comparing the keys by hash code, which means that
+      // multiple distinct keys might be treated as equal by the ordering. To deal with this, we
+      // need to read all keys considered equal by the ordering at once and compare them.
+      new Iterator[Iterator[Product2[K, C]]] {
+        val sorted = mergeSort(iterators, comparator).buffered
+
+        // Buffers reused across elements to decrease memory allocation
+        val keys = new ArrayBuffer[K]
+        val combiners = new ArrayBuffer[C]
+
+        override def hasNext: Boolean = sorted.hasNext
+
+        override def next(): Iterator[Product2[K, C]] = {
+          if (!hasNext) {
+            throw new NoSuchElementException
+          }
+          keys.clear()
+          combiners.clear()
+          val firstPair = sorted.next()
+          keys += firstPair._1
+          combiners += firstPair._2
+          val key = firstPair._1
+          while (sorted.hasNext && comparator.compare(sorted.head._1, key) == 0) {
+            val pair = sorted.next()
+            var i = 0
+            var foundKey = false
+            while (i < keys.size && !foundKey) {
+              if (keys(i) == pair._1) {
+                combiners(i) = mergeCombiners(combiners(i), pair._2)
+                foundKey = true
+              }
+              i += 1
+            }
+            if (!foundKey) {
+              keys += pair._1
+              combiners += pair._2
+            }
+          }
+
+          // Note that we return an iterator of elements since we could've had many keys marked
+          // equal by the partial order; we flatten this below to get a flat iterator of (K, C).
+          keys.iterator.zip(combiners.iterator)
+        }
+      }.flatMap(i => i)
+    } else {
+      // We have a total ordering, so the objects with the same key are sequential.
+      new Iterator[Product2[K, C]] {
+        val sorted = mergeSort(iterators, comparator).buffered
+
+        override def hasNext: Boolean = sorted.hasNext
+
+        override def next(): Product2[K, C] = {
+          if (!hasNext) {
+            throw new NoSuchElementException
+          }
+          val elem = sorted.next()
+          val k = elem._1
+          var c = elem._2
+          while (sorted.hasNext && sorted.head._1 == k) {
+            c = mergeCombiners(c, sorted.head._2)
+          }
+          (k, c)
+        }
+      }
+    }
+  }
+
+}

--- a/core/src/main/scala/org/apache/spark/util/collection/TieredDiskMerger.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/TieredDiskMerger.scala
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util.collection
+
+import org.apache.spark._
+import org.apache.spark.storage.BlockId
+import org.apache.spark.serializer.Serializer
+import org.apache.spark.util.CompletionIterator
+
+import java.util.Comparator
+import java.util.concurrent.{PriorityBlockingQueue, CountDownLatch}
+import java.io.{File, FileOutputStream, BufferedOutputStream}
+
+import scala.collection.mutable.ArrayBuffer
+
+/**
+ * Explain the boundaries of where this starts and why we have second thread
+ *
+ * Manages blocks of sorted data on disk that need to be merged together. Carries out a tiered
+ * merge that will never merge more than spark.shuffle.maxMergeWidth segments at a time.  Except for
+ * the final merge, which merges disk blocks to a returned iterator, TieredDiskMerger merges blocks
+ * from disk to disk.
+ *
+ * TieredDiskMerger carries out disk-to-disk merges in a background thread that can run concurrently
+ * with blocks being deposited on disk.
+ *
+ * When deciding which blocks to merge, it first tries to minimize the number of blocks, and then
+ * the size of the blocks chosen.
+ */
+private[spark] class TieredDiskMerger[K, C](
+    conf: SparkConf,
+    dep: ShuffleDependency[K, _, C],
+    context: TaskContext) extends Logging {
+
+  case class DiskShuffleBlock(blockId: BlockId, file: File, len: Long)
+      extends Comparable[DiskShuffleBlock] {
+    def compareTo(o: DiskShuffleBlock): Int = len.compare(o.len)
+  }
+
+  private val keyComparator: Comparator[K] = dep.keyOrdering.getOrElse(new Comparator[K] {
+    override def compare(a: K, b: K) = {
+      val h1 = if (a == null) 0 else a.hashCode()
+      val h2 = if (b == null) 0 else b.hashCode()
+      h1 - h2
+    }
+  })
+
+  private val maxMergeWidth = conf.getInt("spark.shuffle.maxMergeWidth", 10)
+  private val fileBufferSize = conf.getInt("spark.shuffle.file.buffer.kb", 32) * 1024
+  private val blockManager = SparkEnv.get.blockManager
+  private val ser = Serializer.getSerializer(dep.serializer)
+
+  private val blocks = new PriorityBlockingQueue[DiskShuffleBlock]()
+
+  private val mergeReadyMonitor = new AnyRef()
+  private val mergeFinished = new CountDownLatch(1)
+
+  @volatile private var doneRegistering = false
+
+  def registerOnDiskBlock(blockId: BlockId, file: File): Unit = {
+    assert(!doneRegistering)
+    blocks.put(new DiskShuffleBlock(blockId, file, file.length()))
+
+    mergeReadyMonitor.synchronized {
+      if (shouldMergeNow()) {
+        mergeReadyMonitor.notify()
+      }
+    }
+  }
+
+  /**
+   * Notify the merger that no more on disk blocks will be registered.
+   */
+  def doneRegisteringOnDiskBlocks(): Unit = {
+    doneRegistering = true
+    mergeReadyMonitor.synchronized {
+      mergeReadyMonitor.notify()
+    }
+  }
+
+  def readMerged(): Iterator[Product2[K, C]] = {
+    mergeFinished.await()
+
+    // Merge the final group for combiner to directly feed to the reducer
+    val finalMergedPartArray = blocks.toArray(new Array[DiskShuffleBlock](blocks.size()))
+    val finalItrGroup = blocksToRecordIterators(finalMergedPartArray)
+    val mergedItr =
+      MergeUtil.mergeSort(finalItrGroup, keyComparator, dep.keyOrdering, dep.aggregator)
+
+    blocks.clear()
+
+    // Release the in-memory block and on-disk file when iteration is completed.
+    val completionItr = CompletionIterator[Product2[K, C], Iterator[Product2[K, C]]](
+      mergedItr, releaseShuffleBlocks(finalMergedPartArray))
+
+    new InterruptibleIterator(context, completionItr.map(p => (p._1, p._2)))
+
+  }
+
+  def start() {
+    new DiskToDiskMergingThread().start()
+  }
+
+  /**
+   * Release the left in-memory buffer or on-disk file after merged.
+   */
+  private def releaseShuffleBlocks(shufflePartGroup: Array[DiskShuffleBlock]): Unit = {
+    shufflePartGroup.map { case DiskShuffleBlock(id, file, length) =>
+      try {
+        file.delete()
+      } catch {
+        // Swallow the exception
+        case e: Exception => logWarning(s"Unexpected errors when deleting file: ${
+          file.getAbsolutePath}", e)
+      }
+    }
+  }
+
+  private def blocksToRecordIterators(shufflePartGroup: Seq[DiskShuffleBlock])
+    : Seq[Iterator[Product2[K, C]]] = {
+    shufflePartGroup.map { case DiskShuffleBlock(id, file, length) =>
+      val blockData = blockManager.diskStore.getBytes(id).getOrElse(
+        throw new IllegalStateException(s"cannot get data from block $id"))
+      val itr = blockManager.dataDeserialize(id, blockData, ser)
+      itr.asInstanceOf[Iterator[Product2[K, C]]]
+    }.toSeq
+  }
+
+  /**
+   * Whether we should carry out a disk-to-disk merge now or wait for more blocks or a done
+   * registering notification to come in.
+   *
+   * We want to avoid merging more blocks than we need to. Our last disk-to-disk merge may
+   * merge fewer than maxMergeWidth blocks, as its only requirement is that, after it has been
+   * carried out, <= maxMergeWidth blocks remain. E.g., if maxMergeWidth is 10, no more blocks
+   * will come in, and we have 13 on-disk blocks, the optimal number of blocks to include in the
+   * last disk-to-disk merge is 4.
+   *
+   * While blocks are still coming in, we don't know the optimal number, so we hold off until we
+   * either receive the notification that no more blocks are coming in, or until maxMergeWidth
+   * merge is required no matter what.
+   *
+   * E.g. if maxMergeWidth is 10 and we have 19 or more on-disk blocks, a 10-block merge will put us
+   * at 10 or more blocks, so we might as well carry it out now.
+   */
+  private def shouldMergeNow(): Boolean = doneRegistering || blocks.size() >= maxMergeWidth * 2 - 1
+
+  private class DiskToDiskMergingThread extends Thread {
+    // TODO: there will be more than one of these so we need more unique names?
+    setName("tiered-merge-thread")
+    setDaemon(true)
+
+    override def run() {
+      // Each iteration of this loop carries out a disk-to-disk merge. We remain in this loop until
+      // no more disk-to-disk merges need to be carried out, i.e. when no more blocks are coming in
+      // and the final merge won't need to merge more than maxMergeWidth blocks.
+      while (!doneRegistering || blocks.size() > maxMergeWidth) {
+        while (!shouldMergeNow()) {
+          mergeReadyMonitor.synchronized {
+            mergeReadyMonitor.wait()
+          }
+        }
+
+        if (blocks.size() > maxMergeWidth) {
+          val blocksToMerge = new ArrayBuffer[DiskShuffleBlock]()
+          // Try to pick the smallest merge width that will result in the next merge being the final
+          // merge.
+          val mergeWidth = math.min(blocks.size - maxMergeWidth + 1, maxMergeWidth)
+          (0 until mergeWidth).foreach {
+            blocksToMerge += blocks.take()
+          }
+
+          // Merge the blocks
+          val itrGroup = blocksToRecordIterators(blocksToMerge)
+          val partialMergedIter =
+            MergeUtil.mergeSort(itrGroup, keyComparator, dep.keyOrdering, dep.aggregator)
+          // Write merged blocks to disk
+          val (tmpBlockId, file) = blockManager.diskBlockManager.createTempBlock()
+          val fos = new BufferedOutputStream(new FileOutputStream(file), fileBufferSize)
+          blockManager.dataSerializeStream(tmpBlockId, fos, partialMergedIter, ser)
+          logInfo(s"Merged ${blocksToMerge.size} on-disk blocks into file ${file.getName}")
+
+          releaseShuffleBlocks(blocksToMerge.toArray)
+          blocks.add(DiskShuffleBlock(tmpBlockId, file, file.length()))
+        }
+      }
+
+      mergeFinished.countDown()
+    }
+  }
+}


### PR DESCRIPTION
Some of the changes include:
- Changed ioSortFactor to maxMergeWidth to clarify what it means.
- Changed "partition" to "block" to avoid confusion with Spark's more typical use of the word partition.
- Added header documentation.
- Rearranged and documented the main merge loop.
