### PR TITLE
Some improvements in SortShuffleRead

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleMemoryManager.scala
@@ -92,16 +92,14 @@ private[spark] class ShuffleMemoryManager(maxMemory: Long) extends Logging {
   }
 
   /** Release numBytes bytes for the current thread. */
-  def release(numBytes: Long): Unit = release(numBytes, Thread.currentThread().getId)
-
-  /** Release numBytes bytes for the specific thread. */
-  def release(numBytes: Long, tid: Long): Unit = synchronized {
-    val curMem = threadMemory.getOrElse(tid, 0L)
+  def release(numBytes: Long): Unit =  synchronized {
+    val threadId = Thread.currentThread().getId
+    val curMem = threadMemory.getOrElse(threadId, 0L)
     if (curMem < numBytes) {
       throw new SparkException(
         s"Internal error: release called on ${numBytes} bytes but thread only has ${curMem}")
     }
-    threadMemory(tid) -= numBytes
+    threadMemory(threadId) -= numBytes
     notifyAll()  // Notify waiters who locked "this" in tryToAcquire that memory has been freed
   }
 

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleReader.scala
@@ -135,7 +135,7 @@ private[spark] class SortShuffleReader[K, C](
 
     // Release the in-memory block when iteration is completed.
     val completionItr = CompletionIterator[Product2[K, C], Iterator[Product2[K, C]]](
-      mergedItr, () => {
+      mergedItr, {
         inMemoryBlocks.foreach { block =>
           block.blockData.release()
           shuffleMemoryManager.release(block.blockData.size)
@@ -224,7 +224,7 @@ private[spark] class SortShuffleReader[K, C](
     val completionItr = CompletionIterator[
       (BlockId, Try[ManagedBuffer]),
       Iterator[(BlockId, Try[ManagedBuffer])]](shuffleRawBlockFetcherItr,
-      () => context.taskMetrics.updateShuffleReadMetrics())
+        context.taskMetrics.updateShuffleReadMetrics())
 
     new InterruptibleIterator[(BlockId, Try[ManagedBuffer])](context, completionItr)
   }

--- a/core/src/main/scala/org/apache/spark/util/collection/TieredDiskMerger.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/TieredDiskMerger.scala
@@ -17,11 +17,11 @@
 
 package org.apache.spark.util.collection
 
-import java.io.{File, FileOutputStream, BufferedOutputStream}
+import java.io.File
 import java.util.Comparator
 import java.util.concurrent.{PriorityBlockingQueue, CountDownLatch}
 
-import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable
 
 import org.apache.spark._
 import org.apache.spark.executor.ShuffleWriteMetrics
@@ -159,10 +159,11 @@ private[spark] class TieredDiskMerger[K, C](
    * either receive the notification that no more blocks are coming in, or until maxMergeFactor
    * merge is required no matter what.
    *
-   * E.g. if maxMergeFactor is 10 and we have 19 or more on-disk blocks, a 10-block merge will put us
-   * at 10 or more blocks, so we might as well carry it out now.
+   * E.g. if maxMergeFactor is 10 and we have 19 or more on-disk blocks, a 10-block merge will put
+   * us at 10 or more blocks, so we might as well carry it out now.
    */
-  private def shouldMergeNow(): Boolean = doneRegistering || onDiskBlocks.size() >= maxMergeFactor * 2 - 1
+  private def shouldMergeNow(): Boolean = doneRegistering ||
+    onDiskBlocks.size() >= maxMergeFactor * 2 - 1
 
   private final class DiskToDiskMerger extends Thread {
     setName(s"tiered-merge-thread-${Thread.currentThread().getId}")
@@ -180,7 +181,7 @@ private[spark] class TieredDiskMerger[K, C](
         }
 
         if (onDiskBlocks.size() > maxMergeFactor) {
-          val blocksToMerge = new ArrayBuffer[DiskShuffleBlock]()
+          val blocksToMerge = new mutable.ArrayBuffer[DiskShuffleBlock]()
           // Try to pick the smallest merge width that will result in the next merge being the final
           // merge.
           val mergeFactor = math.min(onDiskBlocks.size - maxMergeFactor + 1, maxMergeFactor)


### PR DESCRIPTION
1. Use BlockObjectWriter to write spilled data, statistics for memory spilled size and disk spilled size.
2. Manged the request shuffle block and its size locally to fix bugs in incorrectness of size uncompression.
3. Some small changes.

@sryza , would you mind taking a look at this. I've fixed the previous issue and made some other changes. Thanks a lot.
