### PR TITLE
Refactored Kafka receiver logic and Kafka testsuites

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/BlockGenerator.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/BlockGenerator.scala
@@ -90,10 +90,10 @@ private[streaming] class BlockGenerator(
   }
 
   /** Change the buffer to which single records are added to. */
-  private def updateCurrentBuffer(time: Long): Unit = synchronized {
+  private def updateCurrentBuffer(time: Long): Unit =  {
     try {
       val newBlockBuffer = currentBuffer
-      currentBuffer = new ArrayBuffer[Any]
+      synchronized { currentBuffer = new ArrayBuffer[Any] }
       if (newBlockBuffer.size > 0) {
         val blockId = StreamBlockId(receiverId, time - blockInterval)
         val newBlock = new Block(blockId, newBlockBuffer)


### PR DESCRIPTION
Changes
- ReliableKafkaStreamSuite was running KafkaStreamSuite tests as well, as it was extending it. So refactored KafkaStreamSuite to create KafkaStreamSuiteBase.
- Used `eventually` blocks instead of `Thread.sleep` to reduce test run times. 
- Other general refactoring the in the ReliableKafkaStreamSuite to minimize duplicate code.
- Refactored ReliableKafkaReceiver to implement the better synchronization, and also improve (hopefully) code cleanliness.
